### PR TITLE
Add ability to control npm proxy environment with --define

### DIFF
--- a/node/defs.bzl
+++ b/node/defs.bzl
@@ -143,13 +143,20 @@ def _npm_library_impl(ctx):
     if ctx.attr.npm_installer_extra_args:
         command_args.extend(ctx.attr.npm_installer_extra_args)
 
+    env = {}
+    if 'HTTP_PROXY' in ctx.var:
+        env['HTTP_PROXY'] = ctx.var['HTTP_PROXY']
+    if 'HTTPS_PROXY' in ctx.var:
+        env['HTTPS_PROXY'] = ctx.var['HTTPS_PROXY']
+
     ctx.action(
         inputs = [shrinkwrap],
         outputs = node_modules_srcs_dict.values(),
         executable = ctx.executable.npm_installer,
         arguments = command_args,
         progress_message = 'installing node modules from {}'.format(shrinkwrap.path),
-        mnemonic = 'InstallNPMModules'
+        mnemonic = 'InstallNPMModules',
+        env = env,
     )
 
     all_node_modules = _new_all_node_modules()

--- a/node/tools/npm/utils.py
+++ b/node/tools/npm/utils.py
@@ -83,6 +83,11 @@ def run_npm(cmd, env=None, cwd=None):
     if env:
         full_env = dict(full_env.items() + env.items())
 
+    if 'HTTP_PROXY' in os.environ:
+        full_env['HTTP_PROXY'] = os.environ['HTTP_PROXY']
+    if 'HTTPS_PROXY' in os.environ:
+        full_env['HTTPS_PROXY'] = os.environ['HTTPS_PROXY']
+
     try:
         ret = subprocess.check_output(
             full_cmd, env=full_env, cwd=cwd, stderr=subprocess.STDOUT


### PR DESCRIPTION
It appears that --action_env is the "proper" way to thread environment
variables into skylark actions, but I didn't have any luck getting that
to work. This way requires the rule to explicitly transfer the setting
from ctx.var to env instead.