### PR TITLE
README: Use http_archive instead of new_http_archive

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ load("@org_dropbox_rules_node//node:defs.bzl", "node_repositories", "NODEJS_BUIL
 
 node_repositories(omit_nodejs=True)
 
-new_http_archive(
+http_archive(
     name = "nodejs",
     url = "https://nodejs.org/dist/v6.11.1/node-v6.11.1-darwin-x64.tar.gz",
     strip_prefix = "node-v6.11.1-darwin-x64",


### PR DESCRIPTION
new_http_archive seems to be deprecated – I'm getting the following with Bazel 0.20.0:

```
ERROR: /Users/miikka/code/livegrep/web/npm/style-loader/BUILD:7:1: every rule of type node_test implicitly depends upon the target '@nodejs//:node', but this target could not be found because of: no such package '@nodejs//': The native new_http_archive rule is deprecated. load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive") for a drop-in replacement.
Use --incompatible_remove_native_http_archive=false to temporarily continue using the native rule.
```

http_archive seems to work.