### PR TITLE
Use native.package_name() instead of PACKAGE_NAME

### DIFF
--- a/node/defs.bzl
+++ b/node/defs.bzl
@@ -580,7 +580,7 @@ def mocha_test(name, srcs=[], deps=[], extra_args=[],
     if not srcs:
         fail("'srcs' cannot be empty")
 
-    root = "$RUNFILES/" + PACKAGE_NAME
+    root = "$RUNFILES/" + native.package_name()
 
     mocha_args = [root + "/" + src for src in srcs]
 
@@ -869,7 +869,7 @@ def webpack_build(name, srcs=[], deps=[], data=[], config='', outs=[], env={},
         extra_args = [
             '--config',
             '$RUNFILES/{pkg}/{config}'.format(
-                pkg=PACKAGE_NAME,
+                pkg=native.package_name(),
                 config=config,
             ),
         ] + extra_args,


### PR DESCRIPTION
`PACKAGE_NAME` has been [deprecated in Bazel 0.13.0](https://github.com/bazelbuild/bazel/blob/master/CHANGELOG.md#release-0130-2018-04-30).